### PR TITLE
Fixes #1

### DIFF
--- a/manifests/cronjob.yaml
+++ b/manifests/cronjob.yaml
@@ -26,5 +26,5 @@ spec:
                     --template='{{range .items}}{{printf "%s %s %s\n" .metadata.namespace .metadata.name .status.message}}{{end}}' \
                     | grep "Pod was terminated in response to imminent node shutdown." \
                     | awk '{print $1, $2}' \
-                    | xargs -n2 kubectl delete pod -n || true
+                    | xargs -r -n2 kubectl delete pod -n || true
           restartPolicy: OnFailure


### PR DESCRIPTION
Job output if there are no pods to delete,

```
i-see-dead-pods-28045665-r6p8m error: flag needs an argument: 'n' in -n
i-see-dead-pods-28045665-r6p8m See 'kubectl delete --help' for usage.
```

Job output with fix and no pods to delete, no output.

Job output with fix and 2 pods in error state,

```
i-see-dead-pods-28045689-qs9wd pod "autobrr-77d6577468-8s9sc" deleted
i-see-dead-pods-28045689-qs9wd pod "smartdns-5667cd8897-4dbkv" deleted
```

Adding the "-r" flag doesn't impact either state in a negative way, and removes an error when there are no pods to delete. (Which should be more often than not)